### PR TITLE
Manage empty items in pathway

### DIFF
--- a/joomla/mod_krizalys_breadcrumbs/renderer/BaseBreadcrumbsRenderer.php
+++ b/joomla/mod_krizalys_breadcrumbs/renderer/BaseBreadcrumbsRenderer.php
@@ -183,6 +183,10 @@ abstract class BaseBreadcrumbsRenderer
         $html   = '';
         $attrs  = $this->getItemContainerAttrs();
 
+        if (!$link || empty($item->link) || empty($item->name) ) {
+                return $html;
+        }       
+
         if ($last) {
             $attrs .= ' class="active"';
         }


### PR DESCRIPTION
Some extensions produce some useless empty slots in pathway, i did not understand why (Eg: Fabrik) Google complains about no item.name in itemListElement so i wrote this quick and dirty hack to remove empty itemListElement